### PR TITLE
Allow custom HTTP methods to be used

### DIFF
--- a/js/jinplace.js
+++ b/js/jinplace.js
@@ -67,6 +67,7 @@
 
 	var option_list = ['type',
 		'url',
+		'method',
 		'data',
 		'loadurl',
 		'elementId',
@@ -411,6 +412,7 @@
 	 */
 	$.fn[pluginName].defaults = {
 		url: document.location.pathname,
+		method: "post",
 		type: "input",
 		textOnly: true,
 		placeholder: '[ --- ]',
@@ -429,7 +431,7 @@
 		 */
 		submitFunction: function(opts, value) {
 			return $.ajax(opts.url, {
-				type: "post",
+				type: opts.method,
 				data: requestParams(opts, value),
 				dataType: 'text',
 

--- a/js/jinplace.js
+++ b/js/jinplace.js
@@ -50,6 +50,7 @@
 	 * @class Options
 	 * @property {!string} type - The type of field. Defaults to 'input'
 	 * @property {string} url - The url to submit to. Defaults to same page
+	 * @property {string} method - The HTTP method to use when submitting. Defaults to POST
 	 * @property {string} data - Text or JSON data as initial editing text
 	 * @property {string} loadurl - The URL to load content for editing
 	 * @property {string} elementId - The ID of the element


### PR DESCRIPTION
Possible solution to #3.

Please suggest if we should be white-listing the methods that the plugin will accept. I'm not sure if that could be abused, but upon testing Firefox simply specified any text i entered as the method (not PUT, DELETE, etc), regardless if it existed or not.